### PR TITLE
luci-mod-network: properly handle wireless devices when adding interf…

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -763,22 +763,25 @@ return view.extend({
 							'class': 'cbi-button cbi-button-positive important',
 							'click': ui.createHandlerFn(this, function(ev) {
 								var nameval = name.isValid('_new_') ? name.formvalue('_new_') : null,
-								    protoval = proto.isValid('_new_') ? proto.formvalue('_new_') : null;
+								    protoval = proto.isValid('_new_') ? proto.formvalue('_new_') : null,
+								    protoclass = protoval ? network.getProtocol(protoval, nameval) : null;
 
 								if (nameval == null || protoval == null || nameval == '' || protoval == '')
 									return;
 
 								return m.save(function() {
-									var section_id = uci.add('network', 'interface', nameval);
+									uci.add('network', 'interface', nameval);
 
-									uci.set('network', section_id, 'proto', protoval);
+									protoclass.set('proto', protoval);
 
 									if (ifname_single.isActive('_new_')) {
-										uci.set('network', section_id, 'ifname', ifname_single.formvalue('_new_'));
+										protoclass.addDevice(ifname_single.formvalue('_new_'));
 									}
 									else if (ifname_multi.isActive('_new_')) {
-										uci.set('network', section_id, 'type', 'bridge');
-										uci.set('network', section_id, 'ifname', L.toArray(ifname_multi.formvalue('_new_')).join(' '));
+										protoclass.set('type', 'bridge');
+										L.toArray(ifname_multi.formvalue('_new_')).map(function(dev) {
+											protoclass.addDevice(dev);
+										});
 									}
 								}).then(L.bind(m.children[0].renderMoreOptionsModal, m.children[0], nameval));
 							})


### PR DESCRIPTION
…aces

Wireless device names must not be added as list/option ifname, but the
network must be backreferenced in config wifi-iface instead in these
cases.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(backported from commit 7b5b7fbcd63af14658ad234cd39c076a823e4629)